### PR TITLE
Fix multiline comments with curly brace in them; commented ended on }

### DIFF
--- a/Razor.tmLanguage
+++ b/Razor.tmLanguage
@@ -229,7 +229,7 @@
 			<key>begin</key>
 			<string>/\*</string>
 			<key>end</key>
-			<string>((?=})|(\*/))</string>
+			<string>\*/</string>
 			<key>name</key>
 			<string>comment.block.cshtml</string>
 		</dict>


### PR DESCRIPTION
I've noticed an error in displaying multiline comments that ended not on */ but on the curly brace }. This PR fixes that. 